### PR TITLE
Use HTTPS API endpoint

### DIFF
--- a/lib/netflix_roulette.rb
+++ b/lib/netflix_roulette.rb
@@ -44,7 +44,7 @@ class NetflixRoulette
   end
   
   class Client
-    API_URL     = URI("http://netflixroulette.net/api/api.php")
+    API_URL     = URI("https://netflixroulette.net/api/api.php")
     API_VERSION = "5.0"
     
     def initialize(query = {})


### PR DESCRIPTION
HTTP endpoint was returning "JSON::ParserError: A JSON text must at least contain two octets!" errors.

Switching to HTTPS endpoint appears to clear it up.